### PR TITLE
reset start time to 0 on stop

### DIFF
--- a/rprof.go
+++ b/rprof.go
@@ -217,6 +217,7 @@ func (p *Rprof) Stop() (*proto.Profile, error) {
 	ts := p.startTime
 	samples := p.samples
 
+	p.startTime = 0
 	p.mu.Unlock()
 
 	duration := time.Now().UnixNano() - ts


### PR DESCRIPTION
`Start()` contains a 
```go
      if p.startTime != 0 {
          return errors.New("profiler already started")
      }
```

But `Stop()` never resets `p.startTime` back to 0 so after the initial call it gets stuck.
This adds a reset of startTime in the stop function.